### PR TITLE
Fix distribution for zenoss repo example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ This LWRP provides an easy way to manage additional APT repositories. Adding a n
     # add the Zenoss repo
     apt_repository "zenoss" do
       uri "http://dev.zenoss.org/deb"
-      components ["main","stable"]
+      distribution "main"
+      components ["stable"]
       action :add
     end
     


### PR DESCRIPTION
Fix distribution and components for the zenoss repo example in the README.

In the zenoss repo definition in `README.md`, `distribution` and `components` are mixed up. While the current example still works, it is not technically correct and should therefore be fixed.
