### PR TITLE
Make :add the default action for apt_repository resources

### DIFF
--- a/resources/repository.rb
+++ b/resources/repository.rb
@@ -19,6 +19,11 @@
 
 actions :add, :remove
 
+def initialize(*args)
+  super
+  @action = :add
+end
+
 #name of the repo, used for source.list filename
 attribute :repo_name, :kind_of => String, :name_attribute => true
 attribute :uri, :kind_of => String


### PR DESCRIPTION
Make :add the default action for apt_repository resources.

Makes `apt_repository`'s behaviour more consistent with various native Chef resources (`file`, `package`, etc).
