### PR TITLE
Update metadata.rb

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -1,3 +1,4 @@
+name              "apt"
 maintainer        "Opscode, Inc."
 maintainer_email  "cookbooks@opscode.com"
 license           "Apache 2.0"


### PR DESCRIPTION
add `name' attribute required by chef 12

see: https://github.com/opscode/chef-rfc/blob/master/rfc015-chef-12.md#require-name-attribute-in-cookbook-metadata
